### PR TITLE
Fixes for openrisc litex uart

### DIFF
--- a/arch/openrisc/boot/dts/or1klitex.dts
+++ b/arch/openrisc/boot/dts/or1klitex.dts
@@ -6,12 +6,12 @@
 	interrupt-parent = <&pic>;
 
 	aliases {
-		serial0 = &serial0;
+		uart0 = &serial0;
 	};
 
 	chosen {
-		bootargs = "earlycon earlyprintk debug keep_bootcon";
-		stdout-path = &serial0;
+		bootargs = "earlycon console=ttyLX0,115200";
+		stdout-path = "uart0:115200";
 	};
 
 	memory@0 {


### PR DESCRIPTION
This is working for me on QEMU (no changes to litex-qemu)

I built with the litex `defconfig`

My build command uses my rootfs which you can find in my `or1k-utils` repo

```
OR1K_UTILS=$HOME/work/openrisc/or1k-utils

make -j5 ARCH=openrisc \
   CROSS_COMPILE=or1k-linux- \
   CONFIG_INITRAMFS_SOURCE="$OR1K_UTILS/initramfs $OR1K_UTILS/initramfs.devnodes"
```